### PR TITLE
Fix la version de pandas à l'installation

### DIFF
--- a/setup/OSX.md
+++ b/setup/OSX.md
@@ -68,7 +68,7 @@ Installez pandas :
 
 ```bash
 $ pip install --upgrade matplotlib
-$ pip install --upgrade pandas
+$ pip install pandas==0.16
 ```
 
 ## Testons notre installation


### PR DESCRIPTION
Hello @ssaunier , 

Comme vu ensemble, il faut que nous fixions les versions des librairies que nous utilisons à l'installation pour éviter les écarts entre les librairies qui évoluent et le contenu du cours.  C'est surtout `pandas` qui est important à fixer. 

**OSX**

On peut préciser la version à l'installation en passant un paramètre. Je propose la version `0.16` , stable et qui correspond au contenu de mon cours.

**Windows**

L'installation par `Canopy` nous laisse moins de marge de manoeuvre. Par défaut (cf liste des packages et leur version [disponible ici](https://www.enthought.com/products/canopy/package-index/) ), Canopy installe la dernière version de Pandas. 

Il semble qu'il est possible d'utiliser la commande `enpkg` pour installer / updater une librairie en particulier. On pourrait donc installer Canopy, puis demander aux élèves de faire : 

`enpkg pandas 0.16`

Il faut toutefois noter qu'il peut y avoir des conflits suivant la configuration des ordis ces élèves (configuration de PATH, virtualenv etc..) voir [cet article sur le sujet](https://support.enthought.com/hc/en-us/articles/204470130-Using-enpkg-to-update-Canopy-EPD-packages). 

**Reste à faire**

- Tester pour Windows
- Updater les contenus sur la sidebar du MOOC

Martin